### PR TITLE
Generate HTML Reports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,6 @@
 cache/
 nb.ipynb
 output
+report.html
 tests/__pycache__/
 tests/samples/

--- a/poetry.lock
+++ b/poetry.lock
@@ -123,6 +123,21 @@ files = [
 frozenlist = ">=1.1.0"
 
 [[package]]
+name = "ansi2html"
+version = "1.8.0"
+description = ""
+optional = false
+python-versions = ">=3.6"
+files = [
+    {file = "ansi2html-1.8.0-py3-none-any.whl", hash = "sha256:ef9cc9682539dbe524fbf8edad9c9462a308e04bce1170c32daa8fdfd0001785"},
+    {file = "ansi2html-1.8.0.tar.gz", hash = "sha256:38b82a298482a1fa2613f0f9c9beb3db72a8f832eeac58eb2e47bf32cd37f6d5"},
+]
+
+[package.extras]
+docs = ["Sphinx", "setuptools-scm", "sphinx-rtd-theme"]
+test = ["pytest", "pytest-cov"]
+
+[[package]]
 name = "appdirs"
 version = "1.4.4"
 description = "A small Python module for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
@@ -273,7 +288,7 @@ us = "^3.1.1"
 type = "git"
 url = "https://github.com/PeopleForBikes/brokenspoke-analyzer"
 reference = "main"
-resolved_reference = "45401910f6e49389b7e2402b85f07aadeebe575e"
+resolved_reference = "2a209b3bce39ecaba169b74a9ea7cd4f37a7a2e3"
 
 [[package]]
 name = "census"
@@ -608,6 +623,17 @@ Pygments = ">=2.9.0,<3.0.0"
 toml = ["tomli (>=1.2.1)"]
 
 [[package]]
+name = "docutils"
+version = "0.20.1"
+description = "Docutils -- Python Documentation Utilities"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "docutils-0.20.1-py3-none-any.whl", hash = "sha256:96f387a2c5562db4476f09f13bbab2192e764cac08ebbf3a34a95d9b1e4a59d6"},
+    {file = "docutils-0.20.1.tar.gz", hash = "sha256:f08a4e276c3a1583a86dce3e34aba3fe04d02bba2dd51ed16106244e8a923e3b"},
+]
+
+[[package]]
 name = "executing"
 version = "1.2.0"
 description = "Get the currently executing AST node of a frame, and other information"
@@ -766,6 +792,16 @@ pyproj = ">=3.0.1"
 shapely = ">=1.7.1"
 
 [[package]]
+name = "htmlmin"
+version = "0.1.12"
+description = "An HTML Minifier"
+optional = false
+python-versions = "*"
+files = [
+    {file = "htmlmin-0.1.12.tar.gz", hash = "sha256:50c1ef4630374a5d723900096a961cff426dff46b48f34d194a81bbe14eca178"},
+]
+
+[[package]]
 name = "idna"
 version = "3.4"
 description = "Internationalized Domain Names in Applications (IDNA)"
@@ -785,6 +821,17 @@ python-versions = ">=3.7"
 files = [
     {file = "iniconfig-2.0.0-py3-none-any.whl", hash = "sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374"},
     {file = "iniconfig-2.0.0.tar.gz", hash = "sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3"},
+]
+
+[[package]]
+name = "install"
+version = "1.3.5"
+description = "Install packages from within code"
+optional = false
+python-versions = ">=2.7, >=3.5"
+files = [
+    {file = "install-1.3.5-py3-none-any.whl", hash = "sha256:0d3fadf4aa62c95efe8d34757c8507eb46177f86c016c21c6551eafc6a53d5a9"},
+    {file = "install-1.3.5.tar.gz", hash = "sha256:e67c8a0be5ccf8cb4ffa17d090f3a61b6e820e6a7e21cd1d2c0f7bc59b18e647"},
 ]
 
 [[package]]
@@ -1457,6 +1504,17 @@ files = [
 ]
 
 [[package]]
+name = "pip"
+version = "23.1.2"
+description = "The PyPA recommended tool for installing Python packages."
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "pip-23.1.2-py3-none-any.whl", hash = "sha256:3ef6ac33239e4027d9a5598a381b9d30880a1477e50039db2eac6e8a8f6d1b18"},
+    {file = "pip-23.1.2.tar.gz", hash = "sha256:0e7c86f486935893c708287b30bd050a36ac827ec7fe5e43fe7cb198dd835fba"},
+]
+
+[[package]]
 name = "platformdirs"
 version = "3.8.0"
 description = "A small Python package for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
@@ -1650,6 +1708,38 @@ pytest = ">=7.0.0"
 [package.extras]
 docs = ["sphinx (>=5.3)", "sphinx-rtd-theme (>=1.0)"]
 testing = ["coverage (>=6.2)", "flaky (>=3.5.0)", "hypothesis (>=5.7.1)", "mypy (>=0.931)", "pytest-trio (>=0.7.0)"]
+
+[[package]]
+name = "pytest-reporter"
+version = "0.5.2"
+description = "Generate Pytest reports with templates"
+optional = false
+python-versions = ">=3.5"
+files = [
+    {file = "pytest-reporter-0.5.2.tar.gz", hash = "sha256:5418505ca48e9bf8a40bf28eda33a9b189a3add57422b722cb8d23f8ecf2edba"},
+    {file = "pytest_reporter-0.5.2-py3-none-any.whl", hash = "sha256:f5cfd4ab231e845709382bdc4c41fa97b942f3eb5caeccce0fb8e76afb6b11fb"},
+]
+
+[package.dependencies]
+pytest = "*"
+
+[[package]]
+name = "pytest-reporter-html1"
+version = "0.8.3"
+description = "A basic HTML report template for Pytest"
+optional = false
+python-versions = ">=3.5"
+files = [
+    {file = "pytest-reporter-html1-0.8.3.tar.gz", hash = "sha256:1f5593e0e14151e7d669d0bf155f108e52a5819ff28259ef25716b2099d37537"},
+    {file = "pytest_reporter_html1-0.8.3-py3-none-any.whl", hash = "sha256:2f7e3120e094ee5c0f93b00ecc908532c951efb1ef7a0661139f2d289fd04f64"},
+]
+
+[package.dependencies]
+ansi2html = ">=1.3.0"
+docutils = "*"
+htmlmin = "*"
+Jinja2 = "*"
+pytest-reporter = ">=0.4.0"
 
 [[package]]
 name = "pytest-rerunfailures"
@@ -2420,4 +2510,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "0726aea9cc41206727f05a48422938f271246beb714649725353ad7b567785fc"
+content-hash = "98e94a3eb9a7264b1af5f51582d86a43c0f014ab78d101db30cbb7d475868293"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,9 @@ python-dotenv = "^1.0.0"
 pandas = "^2.0.2"
 ipykernel = "^6.23.2"
 pytest-rerunfailures = "^11.1.2"
+pip = "^23.1.2"
+install = "^1.3.5"
+pytest-reporter-html1 = "^0.8.3"
 
 [build-system]
 requires = ["poetry-core"]
@@ -34,5 +37,7 @@ force_grid_wrap = 2
 
 [tool.pytest.ini_options]
 minversion = "6.0"
-addopts = "-p no:warnings --reruns 3 --reruns-delay 10"
-
+addopts = "-p no:warnings --reruns 5 --reruns-delay 15 --template=html1/index.html --report=report.html"
+markers = [
+    "usa",
+]


### PR DESCRIPTION
- Uses pytest-reporter-html1 to generate html reports.
- Adds country markers.
- Increases retry attempts and delay.
