### PR TITLE
Clean up code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 __pycache__/
 .DS_Store
 .ruff_cache
-.venv/
+.venv
 .vscode/
 *.pyc
 cache/

--- a/modular_bna/core/bna.py
+++ b/modular_bna/core/bna.py
@@ -76,7 +76,7 @@ def prepare_environment(
         >>>    "CENSUS_YEAR": "2019",
         >>>    "CITY_DEFAULT": "NULL",
         >>>    "NB_COUNTRY": "usa",
-        >>>    "NB_INPUT_SRID": "4236",
+        >>>    "NB_INPUT_SRID": "4326",
         >>>    "PFB_CITY_FIPS": "1150000",
         >>>    "PFB_STATE_FIPS": "11",
         >>>    "PFB_STATE": "dc",

--- a/scripts/22-import_jobs.sh
+++ b/scripts/22-import_jobs.sh
@@ -3,55 +3,36 @@ set -euo pipefail
 [ "${PFB_DEBUG}" -eq "1" ] && set -x
 
 function import_job_data() {
-  # Force to lower case to match the jobs file download paths.
   # Data type is either 'main' or 'aux'.
-  DATA_TYPE="${2:-main}"
+  DATA_TYPE="${1}"
   JOB_FILENAME="${PFB_STATE}_od_${DATA_TYPE}_JT00_${CENSUS_YEAR}.csv"
-  # NB_TEMPDIR="test/usa-az-flagstaff"
   JOB_FILEPATH=${NB_TEMPDIR}/${JOB_FILENAME}
 
   # Create the table.
   TABLE=state_od_${DATA_TYPE}_JT00
   psql -c "DROP TABLE IF EXISTS ${TABLE};"
-  psql -c "CREATE TABLE ${TABLE} (
-    w_geocode varchar(15),
-    h_geocode varchar(15),
-    S000 integer,
-    SA01 integer,
-    SA02 integer,
-    SA03 integer,
-    SE01 integer,
-    SE02 integer,
-    SE03 integer,
-    SI01 integer,
-    SI02 integer,
-    SI03 integer,
-    createdate varchar(32)
-);"
+  psql <<SQL
+CREATE TABLE ${TABLE} (
+  w_geocode varchar(15),
+  h_geocode varchar(15),
+  S000 integer,
+  SA01 integer,
+  SA02 integer,
+  SA03 integer,
+  SE01 integer,
+  SE02 integer,
+  SE03 integer,
+  SI01 integer,
+  SI02 integer,
+  SI03 integer,
+  createdate varchar(32)
+);
+SQL
 
   # Load data.
   psql -c "\copy ${TABLE} FROM '${JOB_FILEPATH}' DELIMITER ',' CSV HEADER;"
 }
 
 echo "Importing jobs data"
-import_job_data "${PFB_STATE}" "main"
-import_job_data "${PFB_STATE}" "aux"
-
-# NB_POSTGRESQL_HOST="${NB_POSTGRESQL_HOST:-127.0.0.1}"
-# NB_POSTGRESQL_DB="${NB_POSTGRESQL_DB:-pfb}"
-# NB_POSTGRESQL_USER="${NB_POSTGRESQL_USER:-gis}"
-# NB_POSTGRESQL_PASSWORD="${NB_POSTGRESQL_PASSWORD:-gis}"
-
-# Use official environment variables instead:
-# PGHOST behaves the same as the host connection parameter.
-# PGHOSTADDR behaves the same as the hostaddr connection parameter. This can be
-#   set instead of or in addition to PGHOST to avoid DNS lookup overhead.
-# PGPORT behaves the same as the port connection parameter.
-# PGDATABASE behaves the same as the dbname connection parameter.
-# PGUSER behaves the same as the user connection parameter.
-# PGPASSWORD behaves the same as the password connection parameter. Use of this
-#   environment variable is not recommended for security reasons, as some
-#   operating systems allow non-root users to see process environment variables
-#   via ps; instead consider using a password file (see Section 34.16).
-
-#CENSUS_YEAR
+import_job_data "main"
+import_job_data "aux"

--- a/tests/test_compare.py
+++ b/tests/test_compare.py
@@ -11,7 +11,7 @@ from modular_bna.core import bna
 # As a result, a delta of 1000 means 10%.
 # 10000 means the delta is disabled until we figure out why the delta is so big
 # in some cases
-DELTA = 1000
+DELTA = 0
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Clean up the code to remove potential sources of errors:

- Changes the assert delta back to 0!
- Revert changes in `import_and_transform_shapefile`.
- Removes duplicated PostGIS projections.
- Makes `osm2psql` use all available cores.
- Fixes doctests.
- Cleans up comments.
- Random code cleanups.
